### PR TITLE
Lmdb

### DIFF
--- a/populate/main.go
+++ b/populate/main.go
@@ -160,7 +160,7 @@ func main() {
 		err = lmdbEnv.SetMapSize(1 << 38) // ~273Gb
 		y.Check(err)
 
-		err = lmdbEnv.Open(*dir+"/lmdb", 0, 0777)
+		err = lmdbEnv.Open(*dir+"/lmdb", lmdb.NoSync, 0777)
 		y.Check(err)
 
 		// Acquire handle


### PR DESCRIPTION
Two tweaks - populate was extremely slow because it's fsyncing after every transaction, changed it to use Nosync.

ReadRandomLmdb seemed to be bottlenecked, changed to a reusable Read txn.