### PR TITLE
Add benchmark for sync vs async fetch

### DIFF
--- a/bench_async_fetch_test.go
+++ b/bench_async_fetch_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/y"
+)
+
+func BenchmarkIterateValueFetch(b *testing.B) {
+	bdb, err := getBadger()
+	y.Check(err)
+	defer bdb.Close()
+	k := make([]byte, 1024)
+	v := make([]byte, Mi)
+	b.ResetTimer()
+
+	b.Run("iterate-async-fetch", func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			var count int
+			opt := badger.IteratorOptions{}
+			opt.PrefetchSize = 256
+			opt.FetchValues = true
+			itr := bdb.NewIterator(opt)
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				vsz := len(item.Value())
+				y.AssertTruef(vsz == *flagValueSize, "Assertion failed. value size is %d, expected %d", vsz, *flagValueSize)
+				{
+					// do some processing.
+					k = safecopy(k, item.Key())
+					v = safecopy(v, item.Value())
+				}
+				count++
+				if count >= 2*Mi {
+					break
+				}
+			}
+			b.Logf("[%d] Counted %d keys\n", j, count)
+		}
+	})
+
+	b.Run("iterate-sync-fetch", func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			var count int
+			opt := badger.IteratorOptions{}
+			opt.FetchValues = false
+			itr := bdb.NewIterator(opt)
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				item := itr.Item()
+				bdb.FillValue(item)
+				vsz := len(item.Value())
+				y.AssertTruef(vsz == *flagValueSize, "Assertion failed. value size is %d, expected %d", vsz, *flagValueSize)
+				{
+					// do some processing.
+					k = safecopy(k, item.Key())
+					v = safecopy(v, item.Value())
+				}
+				count++
+				if count >= 2*Mi {
+					break
+				}
+			}
+			b.Logf("[%d] Counted %d keys\n", j, count)
+		}
+	})
+}


### PR DESCRIPTION
@manishrjain This is to address https://github.com/dgraph-io/badger/issues/170

I have a populated dataset ready in EC2. So if the code looks alrite, i can kick off a run immediately.

```
$ go test -v --bench BenchmarkIterateValueFetch --keys_mil 1 --valsz 128 --dir "/tmp"
goos: linux
goarch: amd64
pkg: github.com/dgraph-io/badger-bench
BenchmarkIterateValueFetch/iterate-async-fetch-4                       1      1000985434 ns/op
--- BENCH: BenchmarkIterateValueFetch/iterate-async-fetch-4
        bench_async_fetch_test.go:39: [0] Counted 635092 keys
BenchmarkIterateValueFetch/iterate-sync-fetch-4                        2       656024234 ns/op
--- BENCH: BenchmarkIterateValueFetch/iterate-sync-fetch-4
        bench_async_fetch_test.go:64: [0] Counted 635092 keys
        bench_async_fetch_test.go:64: [0] Counted 635092 keys
        bench_async_fetch_test.go:64: [1] Counted 635092 keys
PASS
ok      github.com/dgraph-io/badger-bench       3.004s
```